### PR TITLE
Restore telnet prompt display and enable manual commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,6 +69,9 @@ def supports_color() -> bool:
 COLOR_ENABLED = supports_color()
 
 
+_partial_line_pending = False
+
+
 def apply_color(line: str) -> str:
     if not COLOR_ENABLED:
         return line
@@ -90,14 +93,59 @@ def apply_color(line: str) -> str:
 
 
 def print_output(text: str):
+    global _partial_line_pending
+    if not text:
+        return
     text = text.replace("\r\n", "\n").replace("\r", "\n")
-    lines = text.split("\n")
-    for line in lines[:-1]:
-        print(apply_color(line))
-    if lines[-1]:
-        print(apply_color(lines[-1]), end="")
-    else:
-        sys.stdout.flush()
+    if _partial_line_pending and text.lstrip().startswith(("[event]", "[error]")):
+        sys.stdout.write("\n")
+        _partial_line_pending = False
+    chunks = text.splitlines(keepends=True) or [text]
+    for chunk in chunks:
+        if not chunk:
+            continue
+        stripped = chunk[:-1] if chunk.endswith("\n") else chunk
+        sys.stdout.write(apply_color(stripped))
+        if chunk.endswith("\n"):
+            sys.stdout.write("\n")
+            _partial_line_pending = False
+        elif PROMPT_PATTERN.search(stripped):
+            sys.stdout.write("\n")
+            _partial_line_pending = False
+        else:
+            _partial_line_pending = True
+    if text.endswith("\n"):
+        _partial_line_pending = False
+    sys.stdout.flush()
+
+
+def _extract_json_object(text: str) -> Optional[str]:
+    start: Optional[int] = None
+    depth = 0
+    in_string = False
+    escape = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == "}":
+            if depth == 0:
+                continue
+            depth -= 1
+            if depth == 0 and start is not None:
+                return text[start : index + 1]
+    return None
 
 
 @dataclass
@@ -272,10 +320,46 @@ class OllamaAgent:
         payload = payload.strip()
         if not payload:
             return []
+        data: Optional[object]
         try:
             data = json.loads(payload)
         except json.JSONDecodeError:
-            print_output("[error] Ollama returned invalid JSON\n")
+            data = None
+            for line in payload.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                    break
+                except json.JSONDecodeError:
+                    continue
+            if data is None:
+                print_output("[error] Ollama returned invalid JSON\n")
+                return []
+        if isinstance(data, dict) and "commands" not in data and "response" in data:
+            response_payload = data.get("response", "")
+            if isinstance(response_payload, str):
+                response_payload = response_payload.strip()
+                nested: Optional[object] = None
+                if response_payload:
+                    try:
+                        nested = json.loads(response_payload)
+                    except json.JSONDecodeError:
+                        fragment = _extract_json_object(response_payload)
+                        if fragment:
+                            try:
+                                nested = json.loads(fragment)
+                            except json.JSONDecodeError:
+                                nested = None
+                if not isinstance(nested, dict):
+                    print_output("[error] Ollama response did not contain valid command JSON\n")
+                    return []
+                data = nested
+            else:
+                print_output("[error] Ollama response did not contain valid command JSON\n")
+                return []
+        if not isinstance(data, dict):
             return []
         commands = data.get("commands")
         if not isinstance(commands, list):
@@ -332,6 +416,7 @@ class TelnetClient:
 
     def send(self, command: str):
         if self.connection is None:
+            print_output("[error] Not connected\n")
             return
         to_send = command + "\n"
         with self._send_lock:
@@ -404,6 +489,42 @@ class TelnetClient:
         self._buffer = self._buffer[end:]
 
 
+class UserInputHandler:
+    def __init__(self, client: TelnetClient):
+        self.client = client
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self):
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        print_output("[event] Local command input enabled. Type commands and press Enter.\n")
+
+    def stop(self):
+        self._stop_event.set()
+        # Thread is daemonized; no join to avoid blocking on stdin.
+        self._thread = None
+
+    def _run(self):
+        while not self._stop_event.is_set():
+            try:
+                line = sys.stdin.readline()
+            except KeyboardInterrupt:
+                self._stop_event.set()
+                break
+            except Exception:
+                self._stop_event.set()
+                break
+            if line == "":
+                self._stop_event.set()
+                break
+            command = line.rstrip("\r\n")
+            self.client.send(command)
+
+
 class SessionManager:
     def __init__(self, profiles: Sequence[CharacterProfile]):
         if not profiles:
@@ -421,6 +542,7 @@ class SessionManager:
             read_timeout=OLLAMA_READ_TIMEOUT,
             max_retries=OLLAMA_MAX_RETRIES,
         )
+        self.input_handler = UserInputHandler(self.client)
 
     def current_profile(self) -> CharacterProfile:
         return self.profiles[self.index]
@@ -429,18 +551,22 @@ class SessionManager:
         self.index = (self.index + 1) % len(self.profiles)
 
     def run(self):
-        while True:
-            profile = self.current_profile()
-            try:
-                self.client.connect(profile, self.agent)
-            except RuntimeError as exc:
-                print_output(f"[error] {exc}\n")
-                time.sleep(5)
-                continue
-            self._session_loop()
-            self.client.disconnect()
-            self.rotate_profile()
-            time.sleep(3)
+        self.input_handler.start()
+        try:
+            while True:
+                profile = self.current_profile()
+                try:
+                    self.client.connect(profile, self.agent)
+                except RuntimeError as exc:
+                    print_output(f"[error] {exc}\n")
+                    time.sleep(5)
+                    continue
+                self._session_loop()
+                self.client.disconnect()
+                self.rotate_profile()
+                time.sleep(3)
+        finally:
+            self.input_handler.stop()
 
     def _session_loop(self):
         while True:


### PR DESCRIPTION
## Summary
- ensure telnet prompts render on their own line even when the server omits a newline
- add a background stdin handler so local commands are sent to the MUD and surface errors when disconnected
- announce local input availability when the handler starts

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_b_68fb89fd3d90832dab53d9269c7bf6f1